### PR TITLE
Btr mode copilot

### DIFF
--- a/donkeycar/parts/robocars_hat_ctrl.py
+++ b/donkeycar/parts/robocars_hat_ctrl.py
@@ -336,6 +336,13 @@ class RobocarsHatInCtrl(metaclass=Singleton):
                 mode = 'user'
                 user_throttle = 0
 
+        if self.cfg.ROBOCARSHAT_COPILOT_MODE and mode != 'user':
+            user_throttle = user_throttle * (1.0+self.inThrottle)
+            # Full Reverse trigger will stop the car as long as maintained 
+            if self.inThrottle < -0.9:
+                mode = 'user'
+                self.throttle_out = 0
+
         # Discret throttle mode
         if mode=='user':
             # Discret mode, apply profile

--- a/donkeycar/templates/cfg_complete.py
+++ b/donkeycar/templates/cfg_complete.py
@@ -574,7 +574,7 @@ ROBOCARSHAT_PWM_IN_AUX_MAX    =   2000
 
 #ODOM Sensor max value (max matching lowest speed)
 ROBOCARSHAT_ODOM_IN_MAX = 20000
-ROBOCARSHAT_PILOT_MODE = 'local' # Which autonomous mode is triggered by Hat : local_angle or local
+ROBOCARSHAT_PILOT_MODE = 'local_angle' # Which autonomous mode is triggered by Hat : local_angle or local
 ROBOCARSHAT_LOCAL_ANGLE_FIX_THROTTLE = 0.2 # For pilot_angle autonomous mode (aka constant throttle), this is the default throttle to apply
 ROBOCARSHAT_BRAKE_ON_IDLE_THROTTLE = -0.2
 
@@ -595,7 +595,7 @@ ROBOCARSHAT_CH3_FEATURE = 'record/pilot'
 ROBOCARSHAT_CH4_FEATURE = 'none' 
 ROBOCARSHAT_EXPLORE_THROTTLE_SCALER_USING_THROTTLE_CONTROL = False # specific mode when in pilot, throttle control control throttle scaler
 ROBOCARSHAT_EXPLORE_THROTTLE_SCALER_USING_THROTTLE_CONTROL_INC = 0.01
-ROBOCARSHAT_COPILOT_MODE = False #when pilot is engaged, this mode allows user to control throttle while pilot controls steering. 
+ROBOCARSHAT_COPILOT_MODE = False #when pilot is engaged, this mode allows user to control boost on the fixed throttle, while pilot controls steering, works only if pilot mode is local_angle.
 
 ROBOCARSHAT_THROTTLE_EXP_INC = 0.05 
 ROBOCARSHAT_STEERING_EXP_INC = 0.05 

--- a/donkeycar/templates/cfg_complete.py
+++ b/donkeycar/templates/cfg_complete.py
@@ -595,6 +595,7 @@ ROBOCARSHAT_CH3_FEATURE = 'record/pilot'
 ROBOCARSHAT_CH4_FEATURE = 'none' 
 ROBOCARSHAT_EXPLORE_THROTTLE_SCALER_USING_THROTTLE_CONTROL = False # specific mode when in pilot, throttle control control throttle scaler
 ROBOCARSHAT_EXPLORE_THROTTLE_SCALER_USING_THROTTLE_CONTROL_INC = 0.01
+ROBOCARSHAT_COPILOT_MODE = False #when pilot is engaged, this mode allows user to control throttle while pilot controls steering. 
 
 ROBOCARSHAT_THROTTLE_EXP_INC = 0.05 
 ROBOCARSHAT_STEERING_EXP_INC = 0.05 


### PR DESCRIPTION
Add copilot mode on top of local_angle mode
Principle :
- by default, when pilot mode is engaged (in local_angle), throttle is set to fix value defined by ROBOCARSHAT_LOCAL_ANGLE_FIX_THROTTLE
- if throttle stick on remote control is pushed, current thtottle is multiply by a scalar from 1 to 2 (accordingly to stick position)
- if throttle sitck on remote control is push back to full reverse : throttle is set to 0 (stop the car) until stick is released.