### PR TITLE
based on original donkeycar + fix for depth images

### DIFF
--- a/donkeycar/management/kivy_ui.py
+++ b/donkeycar/management/kivy_ui.py
@@ -673,7 +673,7 @@ class DataPlot(PaddedBoxLayout):
             data panel."""
         generator = (t.underlying for t in tub_screen().ids.tub_loader.records)
         self.df = pd.DataFrame(generator).dropna()
-        to_drop = {'cam/image_array'}
+        to_drop = {'cam/image_array', 'cam/undistorted_rgb', 'cam/depth_array'}
         self.df.drop(labels=to_drop, axis=1, errors='ignore', inplace=True)
         self.df.set_index('_index', inplace=True)
         self.unravel_vectors()

--- a/donkeycar/pipeline/sequence.py
+++ b/donkeycar/pipeline/sequence.py
@@ -41,8 +41,12 @@ class TubSeqIterator(SizedIterator[TubRecord]):
 
     next = __next__
 
+class IntermediateIterator(Generic[R, XOut, YOut]):
+    def __init__(self) -> None:
+        pass
 
-class TfmIterator(Generic[R, XOut, YOut],  SizedIterator[Tuple[XOut, YOut]]):
+#class TfmIterator(Generic[R, XOut, YOut],  SizedIterator[Tuple[XOut, YOut]]):
+class TfmIterator(IntermediateIterator[R, XOut, YOut],  SizedIterator[Tuple[XOut, YOut]]):
     def __init__(self,
                  iterable: Iterable[R],
                  x_transform: Callable[[R], XOut],
@@ -65,8 +69,12 @@ class TfmIterator(Generic[R, XOut, YOut],  SizedIterator[Tuple[XOut, YOut]]):
     def __next__(self):
         return next(self.iterator)
 
+class IntermediateIterator2(Generic[X, Y, XOut, YOut]):
+    def __init__(self) -> None:
+        pass
 
-class TfmTupleIterator(Generic[X, Y, XOut, YOut],  SizedIterator[Tuple[XOut, YOut]]):
+#class TfmTupleIterator(Generic[X, Y, XOut, YOut],  SizedIterator[Tuple[XOut, YOut]]):
+class TfmTupleIterator(IntermediateIterator2[X, Y, XOut, YOut],  SizedIterator[Tuple[XOut, YOut]]):
     def __init__(self,
                  iterable: Iterable[Tuple[X, Y]],
                  x_transform: Callable[[X], XOut],
@@ -88,8 +96,11 @@ class TfmTupleIterator(Generic[X, Y, XOut, YOut],  SizedIterator[Tuple[XOut, YOu
     def __next__(self):
         return next(self.iterator)
 
+class IntermediateIterator3(Generic[XOut, YOut]):
+    def __init__(self) -> None:
+        pass
 
-class BaseTfmIterator_(Generic[XOut, YOut],  SizedIterator[Tuple[XOut, YOut]]):
+class BaseTfmIterator_(IntermediateIterator3[XOut, YOut],  SizedIterator[Tuple[XOut, YOut]]):
     '''
     A basic transforming iterator.
     Do no use this class directly.

--- a/setup.py
+++ b/setup.py
@@ -84,6 +84,15 @@ setup(name='donkeycar',
               'plotly',
               'imgaug'
           ],
+          'macm2': [
+            'tensorflow-macos==2.9.2',
+            'tensorflow-metal==0.5.1',
+            'kivy==2.1',
+            'pandas',
+            'plotly',
+            'albumentations'
+
+          ],
           'dev': [
               'pytest',
               'pytest-cov',


### PR DESCRIPTION
- fix from original donkeycar to support mac m2 (new target install name macme : pip install -e .[macm2]
- working with python Python 3.9.18
- (be sure to remove  anu tensorflow and kivy previously installed
- fix in donkeycar/pipeline/sequence.py to prevent MRO exception (https://github.com/autorope/donkeycar/issues/987)
 