### PR TITLE
Manage max_workspace_size depending on platform

### DIFF
--- a/donkeycar/tools/tensorrt/build_save_trt_behavior_engine.py
+++ b/donkeycar/tools/tensorrt/build_save_trt_behavior_engine.py
@@ -1,10 +1,11 @@
 """build_save_trt_behavior_engine
 
 Usage:
-  build_save_trt_behavior_engine.py (--onnx <onnx_model_path>) (--savedtrt <trt_engine_path>)
+  build_save_trt_behavior_engine.py (--onnx <onnx_model_path>) (--savedtrt <trt_engine_path>) [--orin]
 
 Options:
   -h --help     Show this screen.
+     --orin     Specify that this script runs on an orin platform
 """
 
 import tensorrt as trt
@@ -13,10 +14,10 @@ from docopt import docopt
 # TensorRT logger setup
 TRT_LOGGER = trt.Logger(trt.Logger.WARNING)
 
-def build_engine(onnx_file_path, engine_file_path):
+def build_engine(onnx_file_path, engine_file_path, isOrin):
     # Create a builder
     builder = trt.Builder(TRT_LOGGER)
-    
+
     # Set up the network and the parser
     network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.EXPLICIT_BATCH))
     parser = trt.OnnxParser(network, TRT_LOGGER)
@@ -28,7 +29,7 @@ def build_engine(onnx_file_path, engine_file_path):
             for error in range(parser.num_errors):
                 print(parser.get_error(error))
             return None
-    
+
     # Define optimization profile for dynamic input shapes
     profile = builder.create_optimization_profile()
     profile.set_shape('img_in', (1, 165, 320, 3), (1, 165, 320, 3), (1, 165, 320, 3))
@@ -38,9 +39,10 @@ def build_engine(onnx_file_path, engine_file_path):
 
     # Build the engine
     builder.max_batch_size = 1
-    builder.max_workspace_size = 1 << 30  # 1GB
+    if not isOrin:
+        builder.max_workspace_size = 1 << 30  # 1GB
     engine = builder.build_engine(network, config)
-    
+
     # Save the engine to a file
     with open(engine_file_path, 'wb') as f:
         f.write(engine.serialize())
@@ -49,8 +51,9 @@ def main():
     arguments = docopt(__doc__)
     onnx_model_path = arguments['<onnx_model_path>']
     trt_engine_path = arguments['<trt_engine_path>']
+    isOrin = arguments['--orin']
 
-    build_engine(onnx_model_path, trt_engine_path)
+    build_engine(onnx_model_path, trt_engine_path, isOrin)
 
 if __name__ == "__main__":
     main()

--- a/donkeycar/tools/tensorrt/build_save_trt_behavior_engine.py
+++ b/donkeycar/tools/tensorrt/build_save_trt_behavior_engine.py
@@ -14,7 +14,7 @@ from docopt import docopt
 # TensorRT logger setup
 TRT_LOGGER = trt.Logger(trt.Logger.WARNING)
 
-def build_engine(onnx_file_path, engine_file_path, isOrin):
+def build_engine(onnx_file_path, engine_file_path, is_orin):
     # Create a builder
     builder = trt.Builder(TRT_LOGGER)
 
@@ -39,7 +39,7 @@ def build_engine(onnx_file_path, engine_file_path, isOrin):
 
     # Build the engine
     builder.max_batch_size = 1
-    if not isOrin:
+    if not is_orin:
         builder.max_workspace_size = 1 << 30  # 1GB
     engine = builder.build_engine(network, config)
 
@@ -51,9 +51,9 @@ def main():
     arguments = docopt(__doc__)
     onnx_model_path = arguments['<onnx_model_path>']
     trt_engine_path = arguments['<trt_engine_path>']
-    isOrin = arguments['--orin']
+    is_orin = arguments['--orin']
 
-    build_engine(onnx_model_path, trt_engine_path, isOrin)
+    build_engine(onnx_model_path, trt_engine_path, is_orin)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
fix #52 

this commit enable to call `build_save_trt_behavior_engine.py` with a new `--orin` flag that change `max_workspace_size`

On orin run this : `python build_save_trt_behavior_engine.py --onnx model-071.onnx --savedtrt test.trt --orin`
On other run this : `python build_save_trt_behavior_engine.py --onnx model-071.onnx --savedtrt test.trt`