### PR TITLE
Update ansible for SSD install path + support for pc96

### DIFF
--- a/install/ansible/host_vars/pc96.yml
+++ b/install/ansible/host_vars/pc96.yml
@@ -1,0 +1,4 @@
+---
+
+system_hostname: pc96
+platform: orin

--- a/install/ansible/hosts
+++ b/install/ansible/hosts
@@ -8,7 +8,7 @@ orins
 [orins]
 pc93 ansible_host=pc93.local
 pc95 ansible_host=pc95.local
-pc96 ansible_host=pc95.local
+pc96 ansible_host=pc96.local
 
 [nanos]
 pc91 ansible_host=pc91.local

--- a/install/ansible/hosts
+++ b/install/ansible/hosts
@@ -7,10 +7,11 @@ orins
 
 [orins]
 pc93 ansible_host=pc93.local
+pc95 ansible_host=pc95.local
+pc96 ansible_host=pc95.local
 
 [nanos]
 pc91 ansible_host=pc91.local
 pc92 ansible_host=pc92.local
 pc94 ansible_host=pc94.local
-pc95 ansible_host=pc95.local
 strada

--- a/install/ansible/roles/donkeycar/defaults/main/orin-packages.yml
+++ b/install/ansible/roles/donkeycar/defaults/main/orin-packages.yml
@@ -47,7 +47,8 @@ donkeycar_orin_system_packages:
   - tensorrt
   - nvidia-tensorrt-dev
   - python3-libnvinfer-dev
-
+  - cuda-profiler-api-11-4
+  
 donkeycar_orin_pip_packages:
   - testresources==2.0.1
   - futures==3.0.5
@@ -65,7 +66,7 @@ donkeycar_orin_pip_packages:
   # more from install-jp461.sh script
   - numpy==1.23.5
   - scipy==1.10.1
-  - pandas==2.0.1
+  - pandas==2.0.3
   - pkgconfig==1.5.5
   - packaging==23.1
   - grpcio==1.54.2
@@ -79,8 +80,8 @@ donkeycar_orin_pip_packages:
   #- tf2onnx
   - onnxruntime==1.14.1
   - pycuda==2022.2.2 # NEEDS SOME VARS (cuda on path and lib)
-  - depthai==2.24.0.0
-  - depthai-sdk==1.13.1
+  - depthai==2.26.0.0
+  - depthai-sdk==1.14.0
   # allready in tensorflow 2.7.0 install
   #- protobuf==3.19.6
   #- h5py

--- a/install/ansible/roles/donkeycar/defaults/main/orin-packages.yml
+++ b/install/ansible/roles/donkeycar/defaults/main/orin-packages.yml
@@ -48,6 +48,7 @@ donkeycar_orin_system_packages:
   - nvidia-tensorrt-dev
   - python3-libnvinfer-dev
   - cuda-profiler-api-11-4
+  - nvidia-jetpack
   
 donkeycar_orin_pip_packages:
   - testresources==2.0.1

--- a/install/ansible/roles/donkeycar/tasks/install.yml
+++ b/install/ansible/roles/donkeycar/tasks/install.yml
@@ -58,6 +58,14 @@
   tags:
     - pycuda
 
+- name: add pycuda includes on cpath on jetson nano
+  lineinfile:
+    path: "/home/{{ donkeycar_user }}/.bashrc"
+    line: "export CPATH=/usr/local/cuda/include:$CPATH"
+    state: "present"
+  tags:
+    - pycuda
+
 - name: add pycuda on lib path on jetson nano
   lineinfile:
     path: "/home/{{ donkeycar_user }}/.bashrc"


### PR DESCRIPTION
When installing a jetson Orin with SSD, few adjustments were needed : 
- cuda-profiler-api needed to install pycuda
- nvidia-jetpack needed, since install on SSD procedure from NVidia do not install everything (compared to JetPack direct flash on SDCard)
- bump depthai version
- bump panda version

WIP : install of pycuda failed (while it works manually)